### PR TITLE
Fix issue #104: Added setting to auto-enter plugin view

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,11 @@
         "markdown-editor.customCss": {
           "type": "string",
           "default": ""
+        },
+        "markdown-editor.autoEnterPluginViewOnMarkdownOpen": {
+          "type": "boolean",
+          "default": false,
+          "description": "Automatically enter the plugin view when opening a markdown file."
         }
       }
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,6 +21,16 @@ export function activate(context: vscode.ExtensionContext) {
     )
   )
 
+  // Listen for markdown file open events
+  vscode.workspace.onDidOpenTextDocument((doc) => {
+    if (doc.languageId === 'markdown' && doc.uri.scheme === 'file') {
+      const config = vscode.workspace.getConfiguration('markdown-editor')
+      if (config.get<boolean>('autoEnterPluginViewOnMarkdownOpen')) {
+        EditorPanel.createOrShow(context, doc.uri)
+      }
+    }
+  })
+
   context.globalState.setKeysForSync([KeyVditorOptions])
 }
 


### PR DESCRIPTION
# Description

- This PR implements a fix for issue #104.
- Adds a new setting `markdown-editor.autoEnterPluginViewOnMarkdownOpen` to package.json.

# How to test

1. Enable the `markdown-editor.autoEnterPluginViewOnMarkdownOpen` setting.
2. Open a markdown file — the plugin view should open automatically.

# References

Fixes #104