### PR TITLE
fix: auto-sync editor theme when VS Code theme changes

### DIFF
--- a/media-src/src/main.ts
+++ b/media-src/src/main.ts
@@ -23,17 +23,6 @@ function initVditor(msg) {
   console.log('msg', msg)
   let inputTimer
   let defaultOptions: any = {}
-  if (msg.theme === 'dark') {
-    // vditor.setTheme('dark', 'dark')
-    defaultOptions = merge(defaultOptions, {
-      theme: 'dark',
-      preview: {
-        theme: {
-          current: 'dark',
-        },
-      }
-    })
-  }
   defaultOptions = merge(defaultOptions, msg.options, {
     preview: {
       math: {
@@ -41,6 +30,16 @@ function initVditor(msg) {
       }
     }
   })
+  // Apply theme from VS Code AFTER merge so it takes precedence over stored options
+  if (msg.theme === 'dark') {
+    defaultOptions.theme = 'dark'
+    defaultOptions.preview = defaultOptions.preview || {}
+    defaultOptions.preview.theme = { current: 'dark' }
+  } else if (msg.theme === 'light') {
+    defaultOptions.theme = 'classic'
+    defaultOptions.preview = defaultOptions.preview || {}
+    defaultOptions.preview.theme = { current: 'light' }
+  }
   if (window.vditor) {
     vditor.destroy()
     window.vditor = null

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -144,6 +144,19 @@ class EditorPanel {
         this.dispose()
       }
     }, this._disposables)
+    // re-init webview when VS Code theme changes
+    vscode.window.onDidChangeActiveColorTheme((theme) => {
+      this._update({
+        type: 'init',
+        options: {
+          useVscodeThemeColor: EditorPanel.config.get<boolean>(
+            'useVscodeThemeColor'
+          ),
+          ...this._context.globalState.get(KeyVditorOptions),
+        },
+        theme: theme.kind === vscode.ColorThemeKind.Dark ? 'dark' : 'light',
+      })
+    }, null, this._disposables)
     // update EditorPanel when vsc editor changes
     vscode.workspace.onDidChangeTextDocument((e) => {
       if (e.document.fileName !== this._document.fileName) {


### PR DESCRIPTION
## Summary
- Listens for VS Code theme changes (`onDidChangeActiveColorTheme`) and re-initializes the webview with the new theme
- Applies the detected theme after merging stored options, so VS Code's theme always takes precedence over stale saved preferences

## Problem
When switching VS Code themes (light↔dark), the markdown editor retained stale theme settings from stored preferences, causing dark text on dark backgrounds (or vice versa). Users had to manually reset config to fix this.

## Solution
1. Added theme change listener in `extension.ts` that sends a new `init` message to the webview
2. Changed merge order in `main.ts` so the detected VS Code theme is applied last, overriding any stored theme preference