### PR TITLE
fix: update CI workflow to fix deployment

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,23 +7,23 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 14
+          node-version: 20
       - name: Install
         run: yarn; cd ./media-src; yarn
       - name: Test
         run: npm test
+      - name: Publish to Open VSX Registry
+        uses: HaaLeo/publish-vscode-extension@v2
+        id: publishToOpenVSX
+        with:
+          pat: ${{ secrets.OPEN_VSX_TOKEN }}
       - name: Publish to Visual Studio Marketplace
-        uses: HaaLeo/publish-vscode-extension@v0
+        uses: HaaLeo/publish-vscode-extension@v2
         with:
           pat: ${{ secrets.VS_MARKETPLACE_TOKEN }}
           registryUrl: https://marketplace.visualstudio.com
           extensionFile: ${{ steps.publishToOpenVSX.outputs.vsixPath }}
           packagePath: ''
-      - name: Publish to Open VSX Registry
-        uses: HaaLeo/publish-vscode-extension@v0
-        id: publishToOpenVSX
-        with:
-          pat: ${{ secrets.OPEN_VSX_TOKEN }}


### PR DESCRIPTION
## Summary

The deploy CI has been failing since v0.1.14 (2026-02-09) due to outdated dependencies, preventing new versions from being published to the marketplace.

- Update `actions/checkout` v2 → v4
- Update `actions/setup-node` v1 → v4, Node.js 14 → 20
- Update `HaaLeo/publish-vscode-extension` v0 → v2
- Fix step order: Open VSX publish must run before VS Marketplace publish (Marketplace step references `publishToOpenVSX` step's `vsixPath` output)

## Context

Ref #134 — users want to set this as the default editor via `editorAssociations`, which was added in #136, but the marketplace is stuck at v0.1.9 because deployment fails.