### PR TITLE
feat: enable find widget in editor webview

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -128,6 +128,7 @@ class EditorPanel {
       localResourceRoots: [vscode.Uri.file("/"), ...this.getFolders()],
       retainContextWhenHidden: true,
       enableCommandUris: true,
+      enableFindWidget: true,
     }
   }
   private get _fsPath() {


### PR DESCRIPTION
## Summary

Currently `Cmd+F` / `Ctrl+F` doesn't work inside the markdown editor webview because `enableFindWidget` is not set in the webview options.

This one-line change enables VS Code's built-in find widget, allowing users to search within the rendered markdown content.

## Changes

- Added `enableFindWidget: true` to `getWebviewOptions()` in `src/extension.ts`