### PR TITLE
feat: auto-focus editor on open and re-reveal

### DIFF
--- a/media-src/src/main.ts
+++ b/media-src/src/main.ts
@@ -60,6 +60,7 @@ function initVditor(msg) {
       handleToolbarClick()
       fixTableIr()
       fixPanelHover()
+      vditor.focus()
     },
     input() {
       inputTimer && clearTimeout(inputTimer)
@@ -116,6 +117,10 @@ window.addEventListener('message', (e) => {
         vditor.setValue(msg.content)
         console.log('setValue')
       }
+      break
+    }
+    case 'focus': {
+      vditor.focus()
       break
     }
     case 'uploaded': {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -66,6 +66,7 @@ class EditorPanel {
     // If we already have a panel, show it.
     if (EditorPanel.currentPanel) {
       EditorPanel.currentPanel._panel.reveal(column)
+      EditorPanel.currentPanel._panel.webview.postMessage({ command: 'focus' })
       return
     }
     if (!vscode.window.activeTextEditor && !uri) {


### PR DESCRIPTION
## Summary

Currently when the markdown editor opens, the cursor doesn't appear in the editable area — users have to click inside to start typing.

This PR adds automatic focus in two scenarios:

1. **First open**: calls `vditor.focus()` in the Vditor `after` callback so the cursor appears immediately when the editor initializes
2. **Re-reveal**: when `createOrShow` is called on an already-open panel (e.g. via command palette), sends a `focus` message to the webview so the cursor reappears without requiring a click

## Changes

- `media-src/src/main.ts`: added `vditor.focus()` in the `after()` callback and a `focus` message handler
- `src/extension.ts`: sends `{ command: 'focus' }` to the webview after `reveal()`