### PR TITLE
feat: add in-editor find bar with CSS Custom Highlight API

### DIFF
--- a/media-src/src/main.css
+++ b/media-src/src/main.css
@@ -72,3 +72,83 @@ body[data-use-vscode-theme-color="1"] .vditor {
 .jconfirm-buttons button {
   text-transform: none!important;
 }
+
+/* ── Search bar ─────────────────────────────────────────────────────────── */
+#vmd-search-bar {
+  position: fixed;
+  top: 40px; /* sit just below the pinned toolbar */
+  right: 16px;
+  z-index: 9999;
+  display: none;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 8px;
+  border-radius: 6px;
+  background: var(--vscode-editorWidget-background, #252526);
+  border: 1px solid var(--vscode-editorWidget-border, #454545);
+  box-shadow: 0 2px 8px rgba(0,0,0,0.4);
+  font-size: 13px;
+  color: var(--vscode-editorWidget-foreground, #ccc);
+}
+#vmd-search-bar.vmd-search-bar--open {
+  display: flex;
+}
+
+#vmd-search-input {
+  width: 200px;
+  padding: 3px 6px;
+  border: 1px solid var(--vscode-input-border, #3c3c3c);
+  border-radius: 3px;
+  background: var(--vscode-input-background, #3c3c3c);
+  color: var(--vscode-input-foreground, #ccc);
+  font-size: 13px;
+  outline: none;
+}
+#vmd-search-input:focus {
+  border-color: var(--vscode-focusBorder, #007fd4);
+}
+
+#vmd-search-count {
+  min-width: 48px;
+  text-align: center;
+  font-size: 12px;
+  color: var(--vscode-descriptionForeground, #888);
+}
+#vmd-search-count.vmd-search-count--nomatch {
+  color: var(--vscode-errorForeground, #f48771);
+}
+
+#vmd-search-bar button {
+  background: none;
+  border: 1px solid transparent;
+  border-radius: 3px;
+  color: inherit;
+  cursor: pointer;
+  padding: 2px 5px;
+  font-size: 12px;
+  line-height: 1;
+}
+#vmd-search-bar button:hover {
+  border-color: var(--vscode-button-border, #555);
+  background: var(--vscode-toolbar-hoverBackground, rgba(255,255,255,0.1));
+}
+
+#vmd-search-case-label {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  cursor: pointer;
+  font-size: 12px;
+  user-select: none;
+  padding: 2px 4px;
+  border-radius: 3px;
+  border: 1px solid transparent;
+}
+#vmd-search-case-label:hover {
+  border-color: var(--vscode-button-border, #555);
+  background: var(--vscode-toolbar-hoverBackground, rgba(255,255,255,0.1));
+}
+#vmd-search-case-label input {
+  margin: 0;
+  cursor: pointer;
+}

--- a/media-src/src/main.ts
+++ b/media-src/src/main.ts
@@ -17,6 +17,7 @@ import 'vditor/dist/index.css'
 import { t, lang } from './lang'
 import { toolbar } from './toolbar'
 import { fixTableIr } from './fix-table-ir'
+import { initSearch } from './search'
 import './main.css'
 
 function initVditor(msg) {
@@ -61,6 +62,10 @@ function initVditor(msg) {
       fixTableIr()
       fixPanelHover()
       vditor.focus()
+      // Initialize search bar once (idempotent across vditor re-inits)
+      if (!(window as any).__vmdSearch) {
+        ;(window as any).__vmdSearch = initSearch()
+      }
     },
     input() {
       inputTimer && clearTimeout(inputTimer)

--- a/media-src/src/search.ts
+++ b/media-src/src/search.ts
@@ -1,0 +1,211 @@
+/**
+ * In-editor find bar using the CSS Custom Highlight API.
+ * No DOM mutations to the vditor editing area — highlights are rendered by the browser
+ * purely via ::highlight() pseudo-elements, so vditor's internal state is never touched.
+ */
+
+let searchRanges: Range[] = []
+let currentIndex = -1
+let debounceTimer: ReturnType<typeof setTimeout> | null = null
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+function getEditorRoot(): Element | null {
+  return (
+    document.querySelector('.vditor-ir .vditor-reset') ||
+    document.querySelector('.vditor-wysiwyg .vditor-reset') ||
+    document.querySelector('.vditor-sv .vditor-reset')
+  )
+}
+
+function findAllRanges(query: string, caseSensitive: boolean): Range[] {
+  const root = getEditorRoot()
+  if (!root || !query) return []
+
+  const flags = caseSensitive ? 'g' : 'gi'
+  const regex = new RegExp(escapeRegex(query), flags)
+  const ranges: Range[] = []
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT)
+
+  while (walker.nextNode()) {
+    const node = walker.currentNode as Text
+    const text = node.textContent || ''
+    regex.lastIndex = 0
+    let match: RegExpExecArray | null
+    while ((match = regex.exec(text)) !== null) {
+      const range = document.createRange()
+      range.setStart(node, match.index)
+      range.setEnd(node, match.index + match[0].length)
+      ranges.push(range)
+    }
+  }
+  return ranges
+}
+
+function applyHighlights(ranges: Range[], activeIdx: number) {
+  if (typeof CSS === 'undefined' || !CSS.highlights) return
+
+  if (ranges.length > 0) {
+    CSS.highlights.set('vmd-search-result', new (window as any).Highlight(...ranges))
+  } else {
+    CSS.highlights.delete('vmd-search-result')
+  }
+
+  if (activeIdx >= 0 && activeIdx < ranges.length) {
+    CSS.highlights.set('vmd-search-current', new (window as any).Highlight(ranges[activeIdx]))
+  } else {
+    CSS.highlights.delete('vmd-search-current')
+  }
+}
+
+function clearHighlights() {
+  if (typeof CSS !== 'undefined' && CSS.highlights) {
+    CSS.highlights.delete('vmd-search-result')
+    CSS.highlights.delete('vmd-search-current')
+  }
+  searchRanges = []
+  currentIndex = -1
+}
+
+function scrollToActive(ranges: Range[], idx: number) {
+  if (idx < 0 || idx >= ranges.length) return
+  try {
+    const el = ranges[idx].startContainer.parentElement
+    el?.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
+  } catch (_) {
+    // range may be stale after a content mutation
+  }
+}
+
+export function initSearch() {
+  // Inject highlight pseudo-element styles
+  const style = document.createElement('style')
+  style.textContent = `
+    ::highlight(vmd-search-result) {
+      background-color: rgba(255, 216, 0, 0.38);
+      color: inherit;
+    }
+    ::highlight(vmd-search-current) {
+      background-color: rgba(255, 130, 0, 0.65);
+      color: inherit;
+    }
+  `
+  document.head.appendChild(style)
+
+  // Build the search bar
+  const bar = document.createElement('div')
+  bar.id = 'vmd-search-bar'
+  bar.setAttribute('aria-hidden', 'true')
+  bar.innerHTML = `
+    <input id="vmd-search-input" type="text" placeholder="Find…" spellcheck="false" autocomplete="off" />
+    <span id="vmd-search-count"></span>
+    <button id="vmd-search-prev" title="Previous match (Shift+Enter)">&#9650;</button>
+    <button id="vmd-search-next" title="Next match (Enter)">&#9660;</button>
+    <label id="vmd-search-case-label" title="Match case">
+      <input type="checkbox" id="vmd-search-case" /> Aa
+    </label>
+    <button id="vmd-search-close" title="Close (Esc)">&#10005;</button>
+  `
+  document.body.appendChild(bar)
+
+  const input = document.getElementById('vmd-search-input') as HTMLInputElement
+  const countEl = document.getElementById('vmd-search-count') as HTMLSpanElement
+  const prevBtn = document.getElementById('vmd-search-prev') as HTMLButtonElement
+  const nextBtn = document.getElementById('vmd-search-next') as HTMLButtonElement
+  const caseCheckbox = document.getElementById('vmd-search-case') as HTMLInputElement
+  const closeBtn = document.getElementById('vmd-search-close') as HTMLButtonElement
+
+  let isOpen = false
+
+  function open() {
+    isOpen = true
+    bar.classList.add('vmd-search-bar--open')
+    bar.setAttribute('aria-hidden', 'false')
+    input.focus()
+    input.select()
+    if (input.value) runSearch()
+  }
+
+  function close() {
+    isOpen = false
+    bar.classList.remove('vmd-search-bar--open')
+    bar.setAttribute('aria-hidden', 'true')
+    clearHighlights()
+    countEl.textContent = ''
+  }
+
+  function updateCount() {
+    const total = searchRanges.length
+    countEl.textContent = total > 0 ? `${currentIndex + 1}/${total}` : input.value ? '0/0' : ''
+    countEl.classList.toggle('vmd-search-count--nomatch', total === 0 && input.value.length > 0)
+  }
+
+  function runSearch() {
+    searchRanges = findAllRanges(input.value, caseCheckbox.checked)
+    currentIndex = searchRanges.length > 0 ? 0 : -1
+    applyHighlights(searchRanges, currentIndex)
+    if (currentIndex >= 0) scrollToActive(searchRanges, currentIndex)
+    updateCount()
+  }
+
+  function goNext() {
+    if (searchRanges.length === 0) return
+    currentIndex = (currentIndex + 1) % searchRanges.length
+    applyHighlights(searchRanges, currentIndex)
+    scrollToActive(searchRanges, currentIndex)
+    updateCount()
+  }
+
+  function goPrev() {
+    if (searchRanges.length === 0) return
+    currentIndex = (currentIndex - 1 + searchRanges.length) % searchRanges.length
+    applyHighlights(searchRanges, currentIndex)
+    scrollToActive(searchRanges, currentIndex)
+    updateCount()
+  }
+
+  input.addEventListener('input', runSearch)
+  caseCheckbox.addEventListener('change', runSearch)
+
+  input.addEventListener('keydown', (e: KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      e.preventDefault()
+      e.shiftKey ? goPrev() : goNext()
+    } else if (e.key === 'Escape') {
+      e.preventDefault()
+      close()
+    }
+  })
+
+  prevBtn.addEventListener('click', goPrev)
+  nextBtn.addEventListener('click', goNext)
+  closeBtn.addEventListener('click', close)
+
+  // Ctrl+F / Cmd+F — intercept before the browser or VS Code handles it
+  document.addEventListener('keydown', (e: KeyboardEvent) => {
+    if ((e.ctrlKey || e.metaKey) && !e.shiftKey && !e.altKey && e.key === 'f') {
+      e.preventDefault()
+      e.stopPropagation()
+      open()
+    }
+  }, true)
+
+  // When editor content changes, re-run the search so highlight ranges stay valid
+  const observeRoot = () => {
+    const root = getEditorRoot()
+    if (!root) return
+
+    new MutationObserver(() => {
+      if (!isOpen || !input.value) return
+      if (debounceTimer) clearTimeout(debounceTimer)
+      debounceTimer = setTimeout(runSearch, 300)
+    }).observe(root, { childList: true, subtree: true, characterData: true })
+  }
+
+  // Delay observation until vditor has fully mounted
+  setTimeout(observeRoot, 1000)
+
+  return { open, close }
+}

--- a/media-src/src/toolbar.ts
+++ b/media-src/src/toolbar.ts
@@ -1,6 +1,8 @@
 import { t } from "./lang"
 import { confirm } from "./utils"
 
+const searchIcon = '<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" width="18" height="18"><path fill="currentColor" d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/></svg>'
+
 export const toolbar = [
 	{
 		hotkey: '⌘s',
@@ -43,6 +45,16 @@ export const toolbar = [
 	'|',
 	'undo',
 	'redo',
+	'|',
+	{
+		name: 'find',
+		tipPosition: 's',
+		tip: 'Find (Ctrl+F)',
+		icon: searchIcon,
+		click() {
+			;(window as any).__vmdSearch?.open()
+		},
+	},
 	'|',
 	{ name: 'edit-mode', tipPosition: 'e', },
 	{

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -741,10 +741,12 @@ class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
     return data
   }
 
-  private getWebviewOptions(): vscode.WebviewOptions {
+  private getWebviewOptions(): vscode.WebviewOptions & vscode.WebviewPanelOptions {
     return {
       enableScripts: true,
       localResourceRoots: [vscode.Uri.file('/'), ...MarkdownEditorProvider.getFolders()],
+      retainContextWhenHidden: true,
+      enableFindWidget: true,
     }
   }
 


### PR DESCRIPTION
- New search.ts module: floating find bar triggered by Ctrl+F / Cmd+F
- Highlights all matches using CSS Custom Highlight API (no DOM mutation)
- Active match shown in orange; all others in yellow
- Match counter (current/total), case-sensitive toggle
- Prev (Shift+Enter / up arrow) and Next (Enter / down arrow) navigation
- Esc closes the bar and clears highlights
- Toolbar search button added between redo and edit-mode
- Highlights auto-refresh on editor content changes (debounced 300ms)
- MarkdownEditorProvider.getWebviewOptions now includes enableFindWidget: true