### PR TITLE
fix: gutter line numbers drift out of sync after editing

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -207,11 +207,7 @@ class EditorPanel {
 </style>
 <script>
 (function(){
-  window.__lnOrig='';
   window.__lnEnabled=true;
-  window.addEventListener('message',function(e){
-    if(e.data&&e.data.command==='__setOrigContent'){window.__lnOrig=e.data.content||''}
-  });
   var listening=false;
   function addToggle(){
     if(document.getElementById('ln-toggle'))return;
@@ -254,7 +250,10 @@ class EditorPanel {
     }
     var srcLines=[];
     try{
-      var src=window.__lnOrig||'';
+      // Always read the live editor value instead of a snapshot received once at
+      // startup: a stale snapshot drifts out of sync with the rendered blocks as
+      // soon as the document is edited, producing wrong line numbers.
+      var src=(window.vditor&&window.vditor.getValue)?(window.vditor.getValue()||''):'';
       var NL=String.fromCharCode(10);
       var L=src.split(NL);
       var starts=[];
@@ -384,10 +383,6 @@ class EditorPanel {
         }
         switch (message.command) {
           case 'ready': {
-            const md = this._document
-              ? this._document.getText()
-              : ''
-            this._panel.webview.postMessage({ command: '__setOrigContent', content: md })
             this._update({
               type: 'init',
               options: EditorPanel.getVditorOptions(this._context),
@@ -664,7 +659,6 @@ class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
 
       switch (message.command) {
         case 'ready':
-          webviewPanel.webview.postMessage({ command: '__setOrigContent', content: document.getText() })
           updateWebview({
             type: 'init',
             options: EditorPanel.getVditorOptions(this.context),


### PR DESCRIPTION
## Problem
The line-number gutter computes each rendered block's source line by parsing a snapshot of the raw markdown that the extension host sends to the webview exactly once, via a one-off `__setOrigContent` message when the webview first loads.

Any edit made after that point changes the number/position of rendered blocks, but the snapshot is never refreshed. The gutter's block-to-line mapping zips the (stale) snapshot's computed block starts against the (live) rendered DOM blocks by index, so once those two counts diverge the numbers drift, worse the longer a document is edited.

## Fix
Read the live editor value (`vditor.getValue()`) instead of the stale snapshot when computing block-start line numbers, so the mapping always reflects the current document state. Also removes the now-unused `__setOrigContent` message plumbing.

## Testing
Reproduced the drift with a headless-browser harness rendering the real Vditor bundle, editing content, and diffing gutter numbers against the actual source lines before/after the fix. Confirmed the drift is eliminated and numbers stay accurate after edits that add/remove blocks.