### PR TITLE
fix: table of contents / in-page anchor links do nothing when clicked

### DIFF
--- a/media-src/src/utils.ts
+++ b/media-src/src/utils.ts
@@ -104,6 +104,43 @@ export function handleToolbarClick() {
 }
 
 /**
+ * Approximates the GitHub-style heading slug so in-page `#anchor` links (e.g. a Table
+ * of Contents) can be matched against the rendered heading text.
+ */
+function slugifyHeading(text: string): string {
+  return text
+    .trim()
+    // Vditor's IR mode keeps the literal `#`/`##`/... marker as part of the heading's
+    // textContent, unlike the final rendered output, so strip it first.
+    .replace(/^#{1,6}\s*/, '')
+    .toLowerCase()
+    .replace(/[`*_~]/g, '')
+    .replace(/[^\p{L}\p{N}\- ]+/gu, '')
+    // GitHub's heading slugger replaces each space individually rather than collapsing
+    // runs of whitespace, so e.g. "Foo & Bar" (which becomes "foo  bar" once the "&" is
+    // stripped) turns into "foo--bar", not "foo-bar".
+    .replace(/ /g, '-')
+}
+
+/**
+ * Scrolls to the heading matching an in-page `#anchor` link. Returns true if a match
+ * was found and scrolled to.
+ */
+function scrollToHeadingAnchor(fragment: string): boolean {
+  const target = decodeURIComponent(fragment).toLowerCase()
+  const headings = document.querySelectorAll(
+    '.vditor-reset h1, .vditor-reset h2, .vditor-reset h3, .vditor-reset h4, .vditor-reset h5, .vditor-reset h6'
+  )
+  for (const h of Array.from(headings)) {
+    if (slugifyHeading(h.textContent || '') === target) {
+      h.scrollIntoView({ block: 'start', behavior: 'smooth' })
+      return true
+    }
+  }
+  return false
+}
+
+/**
  * Sends raw Markdown link targets to the extension host for opening.
  */
 export function fixLinkClick() {
@@ -113,13 +150,22 @@ export function fixLinkClick() {
   document.addEventListener('click', (e) => {
     const target = e.target as HTMLElement
     const link = target.closest('a')
-    const href = link?.getAttribute('href')
+    // Vditor's IR mode never renders a real `<a href>` for links: it always shows the
+    // raw markdown syntax, with the url held in a `.vditor-ir__marker--link` marker
+    // span inside a `[data-type="a"]` wrapper, instead of a real anchor element.
+    const irLinkMarker = target
+      .closest<HTMLElement>('[data-type="a"]')
+      ?.querySelector('.vditor-ir__marker--link')
+    const href = link?.getAttribute('href') || irLinkMarker?.textContent || undefined
 
-    if (href) {
-      e.preventDefault()
-      e.stopPropagation()
-      openLink(href)
+    if (!href) return
+    e.preventDefault()
+    e.stopPropagation()
+    if (href.startsWith('#')) {
+      scrollToHeadingAnchor(href.slice(1))
+      return
     }
+    openLink(href)
   })
   window.open = (url: string, ...args: any[]) => {
     openLink(url)


### PR DESCRIPTION
## Problem
Vditor's IR mode never renders a real `<a href>` for markdown links: it always shows the raw markdown syntax, keeping the link target inside a `.vditor-ir__marker--link` span within a `[data-type="a"]` wrapper, not a real anchor element.

`fixLinkClick()` only ever looked for `target.closest('a')`, so it silently found nothing for any link -- including in-page anchors such as a document's own Table of Contents -- and clicking simply did nothing.

## Fix
Also detect Vditor's IR-mode link structure and extract the href from its marker span. In-page `#anchor` links are now resolved locally: the fragment is matched against a GitHub-style slug computed from each heading's text, and the matching heading is scrolled into view, instead of being forwarded to the extension host (which only knows how to open files/URLs, not in-document anchors).

## Testing
Used a headless-browser harness rendering the real Vditor bundle against a real multi-section document with a 14-entry Table of Contents, clicking every entry and asserting the correct heading scrolled into view. 13/14 correctly matched (the one miss was a genuine mismatch between the TOC text and the actual heading text in that test document, unrelated to this fix).