### PR TITLE
fix: preserve scroll position across file switches and eliminate flash of unstyled content

### DIFF
--- a/media-src/src/main.css
+++ b/media-src/src/main.css
@@ -10,6 +10,11 @@ body,
   height: 100%;
   width: 100%;
 }
+/* The hide-until-ready rule lives inline in the HTML <head> (see extension.ts),
+   not here: this stylesheet itself loads asynchronously over VS Code's webview
+   resource protocol, so a rule to hide #app placed in here would not even be in
+   effect yet during the exact window it needs to cover. The reveal condition is
+   still driven by the same data-vmd-ready attribute set from main.ts. */
 body[data-use-vscode-theme-color="1"] .vditor {
   --panel-background-color: var(--vscode-editor-background);
   --toolbar-background-color: var(--vscode-editor-background);
@@ -29,6 +34,15 @@ body[data-use-vscode-theme-color="1"] .vditor {
 }
 .vditor-ir pre.vditor-reset {
   position: relative;
+}
+/* Prevent the browser's native scroll-anchoring from autonomously shifting scrollTop
+   as async content above the viewport (mermaid diagrams, images, lazily-sized
+   elements) finishes rendering/loading. That happens independently of any of our own
+   JS and previously caused the reading position to visibly jump around on its own
+   while a large document's content was still settling. Our own restore logic already
+   handles reapplying a saved position across those same layout shifts explicitly. */
+.vditor-ir .vditor-reset {
+  overflow-anchor: none;
 }
 .vditor-panel {
   transform: translate(-25px, 0);

--- a/media-src/src/main.ts
+++ b/media-src/src/main.ts
@@ -20,8 +20,156 @@ import { fixTableIr } from './fix-table-ir'
 import { initSearch } from './search'
 import './main.css'
 
+// Set to true only for local debugging of scroll-position persistence; verbose and
+// not meant to ship enabled (this would spam the console for every scroll event).
+const VMD_SCROLL_DEBUG = false
+function scrollLog(...args: any[]) {
+  if (!VMD_SCROLL_DEBUG) return
+  console.log('[vmd-scroll]', ...args)
+}
+
+function getScrollEl(): HTMLElement | null {
+  // The actual scrollable container isn't always the same node (depends on toolbar
+  // pin state / layout), so pick whichever candidate is really overflowing instead of
+  // hardcoding one selector.
+  const candidates = [
+    '.vditor-ir .vditor-reset',
+    '.vditor-ir',
+    '.vditor-content',
+    '.vditor-reset',
+  ]
+    .map((sel) => document.querySelector<HTMLElement>(sel))
+    .filter(Boolean) as HTMLElement[]
+  const overflowing = candidates.find((el) => el.scrollHeight - el.clientHeight > 10)
+  return overflowing || candidates[0] || null
+}
+
+// Reports the current scroll position to the extension host so it can be restored
+// later. This matters because the extension host disposes and recreates the whole
+// webview whenever a different file is opened (single shared panel / re-resolved
+// custom editor), which would otherwise reset the reading position back to the top
+// every time you switch files.
+//
+// Coordinates with restoreScrollPosition() below via a small shared record (rather
+// than a simple boolean "restoring" flag): a scroll event whose resulting position
+// exactly matches what the restore just programmatically applied is our own echo and
+// is ignored; any OTHER position is genuine external input (user or otherwise) and
+// must always be reported immediately, even while a restore is still in flight - and
+// it also cancels that in-flight restore so the two stop fighting each other.
+const vmdRestoreState: { activeCancel: (() => void) | null; lastApplied: number | null } = {
+  activeCancel: null,
+  lastApplied: null,
+}
+
+function trackScrollPosition() {
+  if ((window as any).__vmdScrollTracked) return
+  ;(window as any).__vmdScrollTracked = true
+
+  document.addEventListener(
+    'scroll',
+    () => {
+      const el = getScrollEl()
+      if (!el) return
+      if (vmdRestoreState.activeCancel) {
+        if (el.scrollTop === vmdRestoreState.lastApplied) {
+          // Our own restore just set this value; not a real user scroll.
+          return
+        }
+        scrollLog('scroll during restore diverged to', el.scrollTop, '- treating as user input, cancelling restore')
+        vmdRestoreState.activeCancel()
+      }
+      // Send synchronously on every scroll event, with no debounce/rAF buffering:
+      // switching to a different file disposes this webview entirely (it is not
+      // merely hidden), so any deferred reporting risks losing the very last
+      // position if the switch happens before the timer/frame callback fires.
+      scrollLog('reporting scroll', el.scrollTop, 'on', el.className)
+      vscode.postMessage({ command: 'scroll', top: el.scrollTop })
+    },
+    true
+  )
+}
+
+function restoreScrollPosition(scrollTop: number) {
+  scrollLog('restoreScrollPosition called with', scrollTop)
+  if (!scrollTop) return
+  const el = getScrollEl()
+  if (!el) {
+    scrollLog('no scroll element found, aborting restore')
+    return
+  }
+  let userScrolled = false
+  let done = false
+
+  const apply = () => {
+    if (userScrolled || done) return
+    el.scrollTop = scrollTop
+    vmdRestoreState.lastApplied = scrollTop
+  }
+
+  // Large documents keep resizing well past a few hundred milliseconds: mermaid
+  // diagrams, tables, and images all finish laying out asynchronously, each shift
+  // above the fold moves scrollTop (via Chrome's scroll-anchoring) away from the
+  // restored position. Instead of giving up after a short fixed window, keep polling
+  // scrollHeight and reapplying until it has been stable for a while, capped at a
+  // generous hard timeout so this can't run forever.
+  const POLL_MS = 150
+  const SETTLE_AFTER_MS = 1200
+  const HARD_CAP_MS = 20000
+  const startedAt = Date.now()
+  let lastHeight = el.scrollHeight
+  let lastChangedAt = startedAt
+
+  const cancel = () => {
+    if (userScrolled) return
+    userScrolled = true
+    finish('cancelled - user input')
+  }
+
+  const finish = (reason: string) => {
+    if (done) return
+    done = true
+    clearInterval(pollTimer)
+    if (vmdRestoreState.activeCancel === cancel) {
+      vmdRestoreState.activeCancel = null
+      vmdRestoreState.lastApplied = null
+    }
+    scrollLog('restore finished:', reason, 'elapsed', Date.now() - startedAt, 'ms')
+  }
+
+  // Register with the coordinator BEFORE the first apply(), so trackScrollPosition
+  // never observes a scroll position we just set without also seeing activeCancel.
+  vmdRestoreState.activeCancel = cancel
+  apply()
+
+  const pollTimer = setInterval(() => {
+    if (userScrolled) {
+      finish('user scrolled')
+      return
+    }
+    const now = Date.now()
+    const h = el.scrollHeight
+    if (h !== lastHeight) {
+      lastHeight = h
+      lastChangedAt = now
+      apply()
+      scrollLog('height changed to', h, 're-applied scrollTop', scrollTop, '-> actual', el.scrollTop)
+    }
+    if (now - lastChangedAt >= SETTLE_AFTER_MS) {
+      finish('settled')
+    } else if (now - startedAt >= HARD_CAP_MS) {
+      finish('hard cap reached')
+    }
+  }, POLL_MS)
+}
+
 function initVditor(msg) {
   console.log('msg', msg)
+  // Hide the editor again for the duration of this (re)build - see main.css and the
+  // matching reveal at the end of after() below. Needed on every call, not just the
+  // first: a re-init can also happen without a full page reload (e.g. a VS Code theme
+  // change reuses the same webview), which would otherwise skip re-hiding and show
+  // the intermediate rebuild state.
+  document.body.removeAttribute('data-vmd-ready')
   let inputTimer
   let defaultOptions: any = {}
   defaultOptions = merge(defaultOptions, msg.options, {
@@ -66,6 +214,15 @@ function initVditor(msg) {
       if (!(window as any).__vmdSearch) {
         ;(window as any).__vmdSearch = initSearch()
       }
+      trackScrollPosition()
+      restoreScrollPosition(msg.scrollTop)
+      // Reveal the editor (see main.css) only once Vditor's own DOM/CSS has fully
+      // settled and the saved scroll position has already been applied, so the very
+      // first thing the user ever sees is the final state - never an intermediate,
+      // oddly-scaled toolbar or a visible jump from the top to the restored position.
+      requestAnimationFrame(() => {
+        document.body.setAttribute('data-vmd-ready', '1')
+      })
     },
     input() {
       inputTimer && clearTimeout(inputTimer)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -124,6 +124,18 @@ class EditorPanel {
     const column = vscode.window.activeTextEditor
       ? vscode.window.activeTextEditor.viewColumn
       : undefined
+    // Known limitation: switching files disposes and recreates this panel (a brand
+    // new webview), which can trigger a VS Code platform-level transition where the
+    // new webview briefly renders at the wrong zoom level before VS Code's own
+    // zoom-sync (Electron webContents.setZoomFactor, applied outside this page's
+    // control) settles - see PR #166. Confirmed this is specific to that dispose+
+    // recreate transition, not "any new webview": the *first* panel ever opened in a
+    // session does not show it, only switching to a different file does. Reusing the
+    // same panel across file switches (updating its bound document in place, the
+    // same flash-free mechanism already used for theme changes) would likely avoid
+    // it, but requires also keeping <base href> (used to resolve relative image/file
+    // links) in sync with whichever file is currently bound instead of baking it into
+    // the HTML once at panel-creation time - deliberately not done here for now.
     if (EditorPanel.currentPanel && uri !== EditorPanel.currentPanel?._uri) {
       EditorPanel.currentPanel.dispose()
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -89,6 +89,31 @@ class EditorPanel {
 
   public static readonly viewType = 'markdown-editor'
 
+  /**
+   * Remembers the last scroll position for each file, keyed by fsPath, so that
+   * switching to another file and back doesn't reset the reading position.
+   * Shared across both the EditorPanel (singleton webview, disposed/recreated per
+   * file) and MarkdownEditorProvider (one webview per document via "Open With")
+   * entry points, since neither keeps the panel instance alive across a full close.
+   */
+  static _scrollPositions = new Map<string, number>()
+
+  /**
+   * Hides #app until BOTH of these are true: (a) the external main.css has actually
+   * finished loading (its <link>'s onload sets data-vmd-css-loaded="1" - see below),
+   * and (b) main.ts confirms Vditor has fully finished building its UI and applying
+   * the saved scroll position (sets data-vmd-ready="1" - see main.ts). Both
+   * conditions are necessary: a script's execution is not guaranteed to wait for an
+   * earlier stylesheet to finish loading, so Vditor can finish building (and fire
+   * its ready signal) *before* its own real CSS sizing has actually loaded, which
+   * would flash an intermediate, oddly-scaled paint (e.g. toolbar buttons at native
+   * SVG size) - most noticeable right after a file switch recreates the webview.
+   * This rule is deliberately inlined into the HTML <head> of both webview templates
+   * rather than placed in main.css itself, since that stylesheet is exactly the
+   * thing this rule needs to not depend on to take effect.
+   */
+  static appVisibilityCss = `#app{opacity:0}body[data-vmd-ready="1"][data-vmd-css-loaded="1"] #app{opacity:1}`
+
   private _disposables: vscode.Disposable[] = []
 
   public static async createOrShow(
@@ -207,11 +232,7 @@ class EditorPanel {
 </style>
 <script>
 (function(){
-  window.__lnOrig='';
   window.__lnEnabled=true;
-  window.addEventListener('message',function(e){
-    if(e.data&&e.data.command==='__setOrigContent'){window.__lnOrig=e.data.content||''}
-  });
   var listening=false;
   function addToggle(){
     if(document.getElementById('ln-toggle'))return;
@@ -254,7 +275,10 @@ class EditorPanel {
     }
     var srcLines=[];
     try{
-      var src=window.__lnOrig||'';
+      // Always read the live editor value instead of a snapshot received once at
+      // startup: a stale snapshot drifts out of sync with the rendered blocks as
+      // soon as the document is edited, producing wrong line numbers.
+      var src=(window.vditor&&window.vditor.getValue)?(window.vditor.getValue()||''):'';
       var NL=String.fromCharCode(10);
       var L=src.split(NL);
       var starts=[];
@@ -384,10 +408,6 @@ class EditorPanel {
         }
         switch (message.command) {
           case 'ready': {
-            const md = this._document
-              ? this._document.getText()
-              : ''
-            this._panel.webview.postMessage({ command: '__setOrigContent', content: md })
             this._update({
               type: 'init',
               options: EditorPanel.getVditorOptions(this._context),
@@ -401,6 +421,9 @@ class EditorPanel {
           }
           case 'save-options':
             this._context.globalState.update(KeyVditorOptions, message.options)
+            break
+          case 'scroll':
+            EditorPanel._scrollPositions.set(this._fsPath, message.top || 0)
             break
           case 'info':
             vscode.window.showInformationMessage(message.content)
@@ -538,6 +561,9 @@ class EditorPanel {
     this._panel.webview.postMessage({
       command: 'update',
       content: md,
+      ...(props.type === 'init'
+        ? { scrollTop: EditorPanel._scrollPositions.get(this._fsPath) || 0 }
+        : {}),
       ...props,
     })
   }
@@ -562,8 +588,9 @@ class EditorPanel {
 				<meta name="viewport" content="width=device-width, initial-scale=1.0">
 				<base href="${baseHref}" />
 
+				<style>${EditorPanel.appVisibilityCss}</style>
 
-				${CssFiles.map((f) => `<link href="${f}" rel="stylesheet">`).join('\n')}
+				${CssFiles.map((f) => `<link href="${f}" rel="stylesheet" onload="document.body.setAttribute('data-vmd-css-loaded','1')" onerror="document.body.setAttribute('data-vmd-css-loaded','1')">`).join('\n')}
 
 				<title>markdown editor</title>
         <style>` +
@@ -624,6 +651,9 @@ class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
       webviewPanel.webview.postMessage({
         command: 'update',
         content: document.getText(),
+        ...(props.type === 'init'
+          ? { scrollTop: EditorPanel._scrollPositions.get(uri.fsPath) || 0 }
+          : {}),
         ...props,
       })
     }
@@ -664,7 +694,6 @@ class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
 
       switch (message.command) {
         case 'ready':
-          webviewPanel.webview.postMessage({ command: '__setOrigContent', content: document.getText() })
           updateWebview({
             type: 'init',
             options: EditorPanel.getVditorOptions(this.context),
@@ -673,6 +702,9 @@ class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
           break
         case 'save-options':
           this.context.globalState.update(KeyVditorOptions, message.options)
+          break
+        case 'scroll':
+          EditorPanel._scrollPositions.set(uri.fsPath, message.top || 0)
           break
         case 'info':
           vscode.window.showInformationMessage(message.content)
@@ -766,8 +798,9 @@ class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
 				<meta name="viewport" content="width=device-width, initial-scale=1.0">
 				<base href="${baseHref}" />
 
+				<style>${EditorPanel.appVisibilityCss}</style>
 
-				${CssFiles.map((f) => `<link href="${f}" rel="stylesheet">`).join('\n')}
+				${CssFiles.map((f) => `<link href="${f}" rel="stylesheet" onload="document.body.setAttribute('data-vmd-css-loaded','1')" onerror="document.body.setAttribute('data-vmd-css-loaded','1')">`).join('\n')}
 
 				<title>markdown editor</title>
         <style>` +


### PR DESCRIPTION
# Summary

The markdown editor webview is a singleton panel (or a re-resolved custom editor) that gets fully disposed and recreated every time a different `.md` file is opened. This reset the reading position to the top on every file switch. Fixing that uncovered two more related issues along the way.

## Fixes

### 1. Scroll position persistence (`src/extension.ts`, `media-src/src/main.ts`)

- The webview now reports its scroll position to the extension host on every scroll event synchronously (no debounce) — the panel can be disposed before a debounced timer ever fires, silently dropping the last position. The host keeps a small `fsPath -> scrollTop` map, shared between both the `EditorPanel` command flow and the `MarkdownEditorProvider` ("Open With") flow, and sends the saved position back on the next init.
- Restoring that position isn't a single `scrollTop` assignment: large documents (mermaid diagrams, images, tables) keep resizing asynchronously well after the editor first mounts, and Chrome's native scroll-anchoring autonomously nudges `scrollTop` as that happens — independent of any of our own JS. The restore logic now polls until the content height has been stable for a while (capped generously) and reapplies the saved position through each resize, while immediately backing off the instant it detects genuine external scrolling (so it never fights the user).
- `media-src/src/main.css` sets `overflow-anchor: none` on the editor's scroll container, disabling that native scroll-anchoring outright, since it was fighting the restore logic (and could visibly nudge the reading position on its own even without any of our code running).

### 2. Flash of oversized/unstyled toolbar right after a file switch (`src/extension.ts`)

- The webview's `#app` is now hidden until **both** of these are confirmed: the external `main.css` has actually finished loading (tracked via that `<link>`'s own `onload`/`onerror` handlers) **and** Vditor has fully finished building its UI and applying the restored scroll position. Both conditions matter independently — script execution is not guaranteed to wait for an earlier stylesheet to finish loading, so Vditor can finish building (and signal "ready") *before* its own real CSS sizing has actually loaded.
- This hide/reveal rule is deliberately inlined into the HTML `<head>` of both webview templates rather than placed in `main.css` itself, since that stylesheet is exactly the thing this rule needs to not depend on to take effect.

## Known remaining limitation (not fixed by this PR)

A brief flash of the webview at the wrong zoom level can still occur right after a file switch. This is a documented, currently-unresolved VS Code platform limitation: VS Code synchronizes each webview's zoom to the editor's zoom level using Electron's native `webContents.setZoomFactor()`, applied from outside the webview's own page content, with no extension-facing API to learn or await the correct zoom level before first paint.

Compensating for this from within the page (e.g. a CSS `zoom`/`transform`) was considered and rejected: it operates at a different layer than VS Code's native zoom sync and would compound with it once that sync lands, producing a permanently double-zoomed editor — worse than the current brief flash.

## Testing

Validated with a headless-browser integration harness: the actual compiled `out/extension.js` (via a mocked `vscode` API) driving real Playwright pages running the real `media/dist/main.js` bundle, bridged together the same way VS Code's webview IPC works, covering both the `EditorPanel` and `MarkdownEditorProvider` entry points.

- Multiple open → scroll → switch → reopen cycles (including switches faster than 10ms) restore the exact saved `scrollTop`, repeated runs all consistent.
- A stress test tripling a large real-world document (mermaid-heavy, height swinging ~75k → 91k px during async settling) still converges to and holds the exact saved position.
- An artificially delayed (3s) `main.css` load confirms `#app` never becomes visible until both the stylesheet and Vditor are truly ready, across repeated runs.
