### PR TITLE
fix: preserve full editor width by mirroring Vditor's centering padding

### DIFF
--- a/media-src/src/main.css
+++ b/media-src/src/main.css
@@ -76,8 +76,15 @@ body[data-use-vscode-theme-color="1"] .vditor {
   display: none;
 }
 
+/* Vditor's setPadding() centers editable content by computing symmetric
+   left/right padding as `(containerWidth - preview.maxWidth) / 2` (maxWidth
+   defaults to 800), applied as an inline style. We override padding-left to a
+   fixed value to leave room for our own gutter/toolbar, but without an equal
+   padding-right override, wide viewports keep vditor's large computed
+   right-padding, leaving a big unused gap on the right side of the editor. */
 .vditor-reset {
   padding-left: 35px !important;
+  padding-right: 35px !important;
 }
 
 .jconfirm {


### PR DESCRIPTION
## Problem
On wide viewports, the editor content (and wide tables) only used about 2/3 of the available width, leaving a large unused gap on the right.

## Root cause
Vditor's internal `setPadding()` computes symmetric centering padding as `(containerWidth - options.preview.maxWidth) / 2` (maxWidth defaults to 800) and applies it as an inline style, e.g. `padding: 10px 437.5px`. This extension's `main.css` already overrode `padding-left` to a fixed `35px !important` (to make room for the custom line-number gutter) but never overrode `padding-right`, leaving Vditor's large computed right-padding in place on wide viewports.

## Fix
Added `padding-right: 35px !important;` to the `.vditor-reset` rule in `media-src/src/main.css`, mirroring the existing `padding-left` override, so the content area uses the full available width symmetrically.

## Testing
- Verified via a headless-browser (Playwright) probe against the built webview bundle: table/content width increased from ~1202px to ~1605px at a 1677px viewport (matching viewport - 35 - 35).
- Verified visually via F5 Extension Development Host with a wide markdown table - content now fills the editor width instead of stopping at ~2/3.
- `npx tsc -p ./ --noEmit` passes with no errors.