### PR TITLE
fix(ci): repair release workflow and switch it to pnpm

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,23 +3,30 @@ on:
   push:
     tags:
       - "*"
+permissions:
+  contents: read
 jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
         with:
-          node-version: 20
+          version: 10
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: pnpm
       - name: Install
-        run: yarn; cd ./media-src; yarn
-      - name: Test
-        run: npm test
+        run: pnpm install --frozen-lockfile
+      - name: Build
+        run: pnpm run build
       - name: Publish to Open VSX Registry
         uses: HaaLeo/publish-vscode-extension@v2
         id: publishToOpenVSX
         with:
           pat: ${{ secrets.OPEN_VSX_TOKEN }}
+          dependencies: false
       - name: Publish to Visual Studio Marketplace
         uses: HaaLeo/publish-vscode-extension@v2
         with:

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
   "scripts": {
     "watch": "foy watch",
     "start": "foy watch",
+    "build": "tsc -p ./ && pnpm --filter media-src build",
     "pub": "foy build && npm version patch && vsce package && vsce publish && git push origin main --tags"
   },
   "devDependencies": {

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,5 @@
 allowBuilds:
   esbuild: true
+  core-js-pure: false
 packages:
   - "./media-src"


### PR DESCRIPTION
The tag-triggered publish job could never succeed:
- The `Test` step ran `npm test`, but there is no `test` script and no
  tests in the repo, so the job aborted before publishing. Dropped it —
  `tsc` already type-checks during the build.
- There was no build step at all. `out/` and `dist/` are gitignored, so
  neither `out/extension.js` (the `main` entry) nor `media/dist/main.js`
  existed in the checkout and `vsce package` failed with "Extension
  entrypoint(s) missing". Added a `build` script and a `Build` step.
- Dependencies were installed with yarn, but the repo is a pnpm
  workspace (only `pnpm-lock.yaml`), and `media-src`'s build script
  shells out to `pnpm`. Now installs via `pnpm/action-setup` +
  `pnpm install --frozen-lockfile` for the whole workspace.