### PR TITLE
fix: external file changes not shown while the editor tab is focused

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,6 +11,18 @@ function showError(msg: string) {
 }
 
 /**
+ * True when a document change came from disk rather than from the webview.
+ *
+ * Webview edits reach the document through applyEdit and always leave it dirty, so a
+ * change that leaves the document clean can only be VS Code reloading a file that
+ * another program wrote. That also means there is no pending webview edit to clobber:
+ * if the webview had unsynced content, the document would still be dirty.
+ */
+function isExternalReload(e: vscode.TextDocumentChangeEvent) {
+  return !e.document.isDirty
+}
+
+/**
  * Opens external URIs directly and resolves local links from the Markdown file.
  */
 async function openMarkdownLink(markdownFileUri: vscode.Uri, href: string) {
@@ -386,9 +398,10 @@ class EditorPanel {
       if (e.document.fileName !== this._document.fileName) {
         return
       }
-      // When webview panel is active, do not sync updates from VS Code editor caused by webview edits back to webview
-      // don't change webview panel when webview panel is focus
-      if (this._panel.active) {
+      // Don't echo the webview's own edits back at it, but always take a change that
+      // came from disk: the panel stays "active" while another program has focus, so
+      // this would otherwise drop every external edit.
+      if (this._panel.active && !isExternalReload(e)) {
         return
       }
       textEditTimer && clearTimeout(textEditTimer)
@@ -682,8 +695,9 @@ class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
       if (e.document.fileName !== document.fileName) {
         return
       }
-      // Do not sync when webview panel is active (avoid circular updates)
-      if (webviewPanel.active) {
+      // Don't echo the webview's own edits back at it, but always take a change that
+      // came from disk - see isExternalReload.
+      if (webviewPanel.active && !isExternalReload(e)) {
         return
       }
       updateWebview()

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,12 +14,16 @@ function showError(msg: string) {
  * True when a document change came from disk rather than from the webview.
  *
  * Webview edits reach the document through applyEdit and always leave it dirty, so a
- * change that leaves the document clean can only be VS Code reloading a file that
- * another program wrote. That also means there is no pending webview edit to clobber:
- * if the webview had unsynced content, the document would still be dirty.
+ * content change that leaves the document clean can only be VS Code reloading a file
+ * that another program wrote. That also means there is no pending webview edit to
+ * clobber: if the webview had unsynced content, the document would still be dirty.
+ *
+ * The contentChanges check matters: onDidChangeTextDocument also fires for pure
+ * dirty-state transitions with an empty contentChanges array, so every save (incl.
+ * autosave) emits a clean-document event that must not be mistaken for a reload.
  */
 function isExternalReload(e: vscode.TextDocumentChangeEvent) {
-  return !e.document.isDirty
+  return e.contentChanges.length > 0 && !e.document.isDirty
 }
 
 /**


### PR DESCRIPTION
## Problem

When another program writes a markdown file that is currently open in the markdown editor, the webview keeps showing stale content. It only picks up the change if you close and reopen the tab.

**Repro**
1. Open a `.md` file with the markdown editor.
2. Keep that tab focused.
3. Edit and save the same file in another editor (vim, another IDE, a script).

Before: the webview keeps the old content indefinitely.
After: it updates as soon as the file changes on disk.

Step 2 matters — with the tab unfocused it already worked, which is why this can look intermittent.

## Cause

Both `onDidChangeTextDocument` listeners use `active` as a direction switch: while the panel is active the webview is treated as the source of truth, so incoming document changes are dropped.

```ts
if (webviewPanel.active) {
  return
}
```

The intent is right — don't echo the webview's own edits back at it and clobber the cursor. But `active` tracks which editor tab is active *within* VS Code, and it stays `true` when VS Code loses OS focus to another application. That is exactly when an external edit happens, so the reload event fires and is discarded every time.

Reopening the tab appears to fix it only because that re-runs `init` and re-reads the document from scratch.

## Fix

Discriminate by *origin* rather than focus. Webview edits reach the document through `applyEdit` and always leave it dirty, so a **content** change that leaves the document **clean** can only be VS Code reloading a file another program wrote:

```ts
function isExternalReload(e: vscode.TextDocumentChangeEvent) {
  return e.contentChanges.length > 0 && !e.document.isDirty
}

if (webviewPanel.active && !isExternalReload(e)) {
  return
}
```

This also guarantees there is nothing to clobber: if the webview had unsynced content, the document would still be dirty, so the update is skipped exactly when skipping is correct.

The `contentChanges.length > 0` condition is load-bearing. Per the API docs, `onDidChangeTextDocument` fires not only for content changes but also for pure dirty-state transitions, which carry an **empty** `contentChanges` array — notably every save. Without the condition, a save (especially `files.autoSave: afterDelay`) emits a clean-document event that gets misread as a disk reload, and the full document is pushed back into the webview mid-typing: `setValue` re-renders and jumps the cursor to the top every couple of seconds. A genuine disk reload always carries real `contentChanges` on a clean document (VS Code applies the dirty flag before firing content-change events, see `extHostDocuments.ts`), so the discrimination is exact.

No feedback loop is introduced — vditor's `setValue` runs with `enableInput: false`, so pushing content back does not re-fire the webview's `input` handler.

Affects both entry points (`EditorPanel` and `MarkdownEditorProvider`); fixed in both.

## Notes

- Verified manually against the repro above, and `tsc -p ./` is clean.
- Also verified with autosave enabled: typing in WYSIWYG mode no longer refreshes the editor or resets the cursor when the file saves.
- Scoped deliberately narrow: one helper plus the two guard conditions, no behavior change for webview-originated edits.
